### PR TITLE
chore(env): add direnv configuration for Node.js 24

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+# Load Node.js 24 development environment from system repository
+use flake github:aytordev/system#devShells.aarch64-darwin.node-24


### PR DESCRIPTION
- Configure direnv to use nix develop from system repository
- Load Node.js 24 development environment automatically
- Provides npm, yarn, and pnpm package managers